### PR TITLE
Added gcc-arm-embedded toolchain from launchpad.net/gcc-arm-embedded

### DIFF
--- a/gcc-arm-embedded.rb
+++ b/gcc-arm-embedded.rb
@@ -1,0 +1,23 @@
+require 'formula'
+
+class GccArmEmbedded < Formula
+  homepage 'https://launchpad.net/gcc-arm-embedded'
+  url 'https://launchpad.net/gcc-arm-embedded/4.8/4.8-2014-q1-update/+download/gcc-arm-none-eabi-4_8-2014q1-20140314-mac.tar.bz2'
+  sha1 'b40c4127f641170f016b77ad423caf8dfd46faac'
+
+  version "4_8-2014q1-20140314"
+
+  def install
+    bin.install Dir['bin/*']
+    lib.install Dir['lib/*']
+    (prefix/'arm-none-eabi').install Dir['arm-none-eabi/**']
+
+    man1.install Dir['share/doc/gcc-arm-none-eabi/man/man1/*']
+    man7.install Dir['share/doc/gcc-arm-none-eabi/man/man7/*']
+    doc.install Dir['share/doc/gcc-arm-none-eabi/*']
+  end
+
+  test do
+    system bin/"arm-none-eabi-g++", "-v"
+  end
+end


### PR DESCRIPTION
Pre-built GNU toolchain from ARM Cortex-M & Cortex-R processors (Cortex-M0/M0+/M3/M4, Cortex-R4/R5/R7).

Also available as source but due to build complexity it's preferred to use binary distribution.