### PR TITLE
stack 0.1.2.0 (new formula)

### DIFF
--- a/stack.rb
+++ b/stack.rb
@@ -1,0 +1,10 @@
+class Stack < Formula
+  desc "The Haskell Tool Stack"
+  homepage "https://www.stackage.org/"
+  url "https://github.com/commercialhaskell/stack/releases/download/v0.1.2.0/stack-0.1.2.0-x86_64-osx.gz"
+  sha256 "6e1039d9c5144fb03dbfb1f569a830724593191305998e9be87579d985feb36c"
+
+  def install
+    bin.install "stack-0.1.2.0-x86_64-osx" => "stack"
+  end
+end

--- a/stack.rb
+++ b/stack.rb
@@ -7,4 +7,8 @@ class Stack < Formula
   def install
     bin.install "stack-0.1.2.0-x86_64-osx" => "stack"
   end
+
+  test do
+    system "#{bin}/stack", "--version"
+  end
 end


### PR DESCRIPTION
stack is a cross-platform program for developing Haskell projects.
It is aimed at Haskellers both new and experienced.

Currently it can't be built from the source using GHC provided by Homebrew.

https://github.com/commercialhaskell/stack/wiki/Downloads#os-x
> Note: due to GHC bug 10322, building stack from source fails with GHC 7.10.1. This bug will be fixed in 7.10.2, but in the meantime, we recommend using GHC 7.8.4 on OS X.

See also: https://github.com/Homebrew/homebrew/pull/41626 https://github.com/Homebrew/homebrew/pull/40534