### PR TITLE
mpress: restore test of version reported by program

### DIFF
--- a/mpress.rb
+++ b/mpress.rb
@@ -22,6 +22,10 @@ class Mpress < Formula
   end
 
   test do
+    assert_match(/MACHO-MPRESS v#{version}$/,
+                 shell_output("#{bin}/mpress", 1),
+                 "Version in formula should match version of binary")
+
     test_program = <<-EOS.undent
     #include <stdio.h>
     int main() { puts("Hello world!"); }


### PR DESCRIPTION
In my last pull request, I included a test to verify that the version in the formula matched the version reported by the binary.

Because the version is not a part of the download URL, if the download ever changes, there is the risk that someone will spot the mismatched SHA hash and just slap in a corrected SHA without investigating why it changed (such as [happened with Perforce a few days ago](https://github.com/Homebrew/homebrew-binary/pull/238)). That's what the test is meant to catch.