### PR TITLE
Update perforce-proxy to 16.1

### DIFF
--- a/perforce-proxy.rb
+++ b/perforce-proxy.rb
@@ -1,14 +1,14 @@
 class PerforceProxy < Formula
   desc "Proxy for Perforce applications"
   homepage "http://www.perforce.com/"
-  version "2015.2.1252060"
+  version "2016.1.1374211"
 
   if MacOS.prefer_64_bit?
-    url "http://filehost.perforce.com/perforce/r15.2/bin.darwin90x86_64/p4p"
-    sha256 "ee6eb300095edcaf36cfea3d5d44265eb3fb8886d284bd7b4782fe246a3e3a26"
+    url "http://filehost.perforce.com/perforce/r16.1/bin.darwin90x86_64/p4p"
+    sha256 "23d868aa4d2eb48dff8e5d2a1e8057483d97c1c08716df67990b6d831813cac8"
   else
-    url "http://filehost.perforce.com/perforce/r15.2/bin.darwin90x86/p4p"
-    sha256 "876d021cc69ac27dfeaf67db81f1cab110c708d1826c447fb73172eb8cb6ae8a"
+    url "http://filehost.perforce.com/perforce/r16.1/bin.darwin90x86/p4p"
+    sha256 "e8c98c2c52fc5ef91961c85b30b0f8ce62f7783ff22c9f193be35a888aed902c"
   end
 
   bottle :unneeded
@@ -17,6 +17,8 @@ class PerforceProxy < Formula
     bin.install "p4p"
     (var+"p4p").mkpath
   end
+  
+  plist_options :startup => true
 
   def caveats; <<-EOS.undent
     To use the Perforce proxy to access your Perforce server, set your P4PORT

--- a/perforce-proxy.rb
+++ b/perforce-proxy.rb
@@ -5,7 +5,7 @@ class PerforceProxy < Formula
 
   if MacOS.prefer_64_bit?
     url "http://filehost.perforce.com/perforce/r15.2/bin.darwin90x86_64/p4p"
-    sha256 "f04604088b917cfbc932380f8cd205d7c508911d7cc98f00070d9d458e00101b"
+    sha256 "ee6eb300095edcaf36cfea3d5d44265eb3fb8886d284bd7b4782fe246a3e3a26"
   else
     url "http://filehost.perforce.com/perforce/r15.2/bin.darwin90x86/p4p"
     sha256 "876d021cc69ac27dfeaf67db81f1cab110c708d1826c447fb73172eb8cb6ae8a"

--- a/perforce-proxy.rb
+++ b/perforce-proxy.rb
@@ -17,7 +17,7 @@ class PerforceProxy < Formula
     bin.install "p4p"
     (var+"p4p").mkpath
   end
-  
+
   plist_options :startup => true
 
   def caveats; <<-EOS.undent


### PR DESCRIPTION
This should address:
```
$ brew install  homebrew/binary/perforce-proxy
==> Installing perforce-proxy from homebrew/binary
==> Downloading http://filehost.perforce.com/perforce/r15.2/bin.darwin90x86_64/p4p
######################################################################## 100.0%
Error: SHA256 mismatch
Expected: f04604088b917cfbc932380f8cd205d7c508911d7cc98f00070d9d458e00101b
Actual: ee6eb300095edcaf36cfea3d5d44265eb3fb8886d284bd7b4782fe246a3e3a26
Archive: /Library/Caches/Homebrew/perforce-proxy-2015.2.1252060
To retry an incomplete download, remove the file above.
```