### PR TITLE
kwm version 3.0.1

### DIFF
--- a/kwm.rb
+++ b/kwm.rb
@@ -1,8 +1,8 @@
 class Kwm < Formula
   desc "Tiling window manager with focus follows mouse for OSX."
   homepage "https://koekeishiya.github.io/kwm/"
-  url "https://github.com/koekeishiya/kwm/releases/download/v3.0.0/Kwm-3.0.0.zip"
-  sha256 "f1708138b89043e3a37e3d802265b288170d0d7d99df98f1a847a1281247ee9e"
+  url "https://github.com/koekeishiya/kwm/releases/download/v3.0.1/Kwm-3.0.1.zip"
+  sha256 "5c7eb97d6b39e7e61b9fbb30a2fa4a99897b7280b9c4eacf54c58094e6b11c8f"
 
   def install
     bin.install "kwmc"


### PR DESCRIPTION
Changes:

- Fixed minor memory leak.
- Fixed an issue with miniaturizing a window.
- Some code optimization.
- Fixed an issue causing autoraise to stop working after closing / miniaturizing a window.
- window -f west | east and window -f prev | next will focus the first | last leaf node when no window has focus.
- space -fExperimental should try to focus the window which OSX would've focused when entering that space.