### PR TITLE
 Updated perforce to version 2016.1.1411799

### DIFF
--- a/perforce.rb
+++ b/perforce.rb
@@ -1,14 +1,14 @@
 class Perforce < Formula
   desc "Revision control system"
   homepage "http://www.perforce.com/"
-  version "2016.1.1404799"
+  version "2016.1.1411799"
 
   if MacOS.prefer_64_bit?
     url "https://www.perforce.com/downloads/perforce/r16.1/bin.macosx105x86_64/p4"
-    sha256 "0f91b86f11e98ac8078500da392d4a55a65d74899bd507133c40de3cb220feb4"
+    sha256 "85153a60d75d84b172320e0d9348d0da67979f24a2e63650e5febf005afac778"
   else
     url "https://www.perforce.com/downloads/perforce/r16.1/bin.macosx105x86/p4"
-    sha256 "4f5c9ad5f46497f16afc06a7c7e755079d754dfd64c3eaf229e3e51643db6e7d"
+    sha256 "ddc3272687038b1b507017f6a702e9bdf41b8faf6d5b89ca27e0fc9b1879ad4f"
   end
 
   bottle :unneeded


### PR DESCRIPTION
Perforce released a new command line client version:
https://www.perforce.com/resources/software-release-index

Using the latest sha256:

64-bit:
http://cdist2.perforce.com/perforce/r16.1/bin.macosx105x86_64/SHA256SUMS
32-bit:
http://cdist2.perforce.com/perforce/r16.1/bin.macosx105x86/SHA256SUMS